### PR TITLE
Add Assets/Models to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Game Config Settings
 Assets/Config.ini
 
+# Game assets - using Dropbox w/ symlinks instead
+Assets/Models
+
 # User-specific files
 *.suo
 *.user


### PR DESCRIPTION
We should probably not commit models. For now I'm using Dropbox and symlinking the models folder from the Dropbox folder to my game assets folder.