### PR TITLE
Player Direction

### DIFF
--- a/Client/ClientGameObject.cpp
+++ b/Client/ClientGameObject.cpp
@@ -1,5 +1,6 @@
 #include "ClientGameObject.h"
 #include <glm/gtx/transform.hpp>
+#include <glm/gtx/euler_angles.hpp>
 
 ClientGameObject::ClientGameObject(std::unique_ptr<GameObject> gameObject)
 : gameObject(std::move(gameObject)) { }
@@ -16,6 +17,7 @@ void ClientGameObject::draw(
 
 		// TODO (bhang): add rotation support (quaternions or euler angles?)
 		auto modelTransform = glm::translate(gameObject->getPosition())
+			* glm::toMat4(gameObject->getOrientation())
 			* glm::scale(gameObject->getScale());
 		auto modelInvT = glm::transpose(glm::inverse(mat3(modelTransform)));
 

--- a/Client/Game.cpp
+++ b/Client/Game.cpp
@@ -207,8 +207,7 @@ void Game::updateInputs() {
 	// Sending player input 
 	NetBuffer buffer(NetMessage::PLAYER_INPUT);
 	buffer.write(keyInputs);
-	buffer.write(theta);
-	buffer.write(phi);
+	buffer.write(camera->getForward());
 	Network::send(buffer);
 }
 
@@ -234,7 +233,7 @@ void Game::update(float dt) {
 	}
 
 	if (playerObj) {
-		auto offset = playerObj->getDirection() * 10.0f + vec3(0, 2, 0);
+		auto offset = camera->getForward() * -10.0f + vec3(0, 2, 0);
 		camera->setPosition(playerObj->getPosition() + offset);
 	}
 }

--- a/Client/Game.cpp
+++ b/Client/Game.cpp
@@ -171,10 +171,14 @@ void Game::updateScreenDimensions(int width, int height) {
 }
 
 void Game::updateInputs() {
+	// The camera can look up/down less than 90 degrees.
+	constexpr auto MAX_PITCH_OFFSET = glm::pi<float>() / 2.0f - 0.00001f;
+
 	float mouseMoveScale = mouseSensitivity * 0.001f;
 	theta += (float)Input::getMouseDeltaX() * mouseMoveScale;
 	phi += (float)Input::getMouseDeltaY() * mouseMoveScale;
 
+	phi = glm::clamp(phi, -MAX_PITCH_OFFSET, MAX_PITCH_OFFSET);
 	camera->setEyeAngles(vec3(-phi, theta, 0));
 
 	int keyInputs = 0;

--- a/Client/Game.h
+++ b/Client/Game.h
@@ -46,6 +46,8 @@ class Game {
 	GameState gameState;
 	Player *playerObj = nullptr;
 
+	void updateInputs();
+
 public:
 	bool shouldExit = false;
 	Game();

--- a/Server/GameEngine.cpp
+++ b/Server/GameEngine.cpp
@@ -172,16 +172,11 @@ void GameEngine::doCollisionInteractions() {
 }
 
 void GameEngine::removeDeadObjects() {
-	vector<GameObject *> preservedGameObjects;
 	for (GameObject * gameObject : gameState.gameObjects) {
 		if (gameObject && gameObject->deleteOnServerTick()) {
 			delete gameObject;
 		}
-		else {
-			preservedGameObjects.push_back(gameObject);
-		}
 	}
-	gameState.gameObjects = preservedGameObjects;
 }
 
 void GameEngine::updateGameObjectsOnServerTick() {

--- a/Server/GameEngine.cpp
+++ b/Server/GameEngine.cpp
@@ -109,23 +109,24 @@ vec3 GameEngine::movementInputToVector(int movementInput) {
 }
 
 void GameEngine::movePlayers(vector<PlayerInputs> & playerInputs) {
-	vector<int> aggregatePlayerMovements;
-	//cout << "playerInputs size: " << playerInputs.size() << endl;
-	// Use bitwise or to get all player inputs within one server tick
-	for (int i = 0; i < gameState.players.size(); i++) {
-		aggregatePlayerMovements.push_back(0);
-	}
+	vector<int> aggregatePlayerMovements(gameState.players.size());
+	vector<vec3> directions(gameState.players.size());
+
 	for (PlayerInputs playerInput : playerInputs) {
-		aggregatePlayerMovements[playerInput.id] = aggregatePlayerMovements[playerInput.id] | playerInput.inputs;
+		aggregatePlayerMovements[playerInput.id] |= playerInput.inputs;
+		directions[playerInput.id] = playerInput.direction;
 	}
+
 	for (int i = 0; i < gameState.players.size(); i++) {
-		aggregatePlayerMovements[i] = aggregatePlayerMovements[i] & MOVEMENT_MASK;
-}
-	// Move all players
-	for (int i = 0; i < gameState.players.size(); i++) {
+		auto player = gameState.players[i];
+		if (!player) { continue; }
+		auto movement = aggregatePlayerMovements[i] & MOVEMENT_MASK;
+
+		player->setDirection(directions[i]);
+
 		// TODO: prevent two players from moving to the same spot
 		// gameState.players[i]->move(movementInputToVector(aggregatePlayerMovements[i]));
-		noCollisionMove(gameState.players[i], movementInputToVector(aggregatePlayerMovements[i]));
+		noCollisionMove(player, movementInputToVector(movement));
 		//cout << aggregatePlayerMovements[i] << "   " << glm::to_string(gameState.players[i]->getPosition()) << endl;
 	}
 }

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -27,11 +27,10 @@ int main(int argc, char **argv) {
 	// Handle player keyboard/mouse inputs
 	auto handlePlayerInput = [&playerInputs](Connection *c, NetBuffer &buffer) {
 		PlayerInputs input;
-		auto inputTuple = buffer.read< tuple<int,float,float> >();
 		input.id = c->getId();
-		input.inputs = std::get<0>(inputTuple);
-		input.theta = std::get<1>(inputTuple);
-		input.phi = std::get<2>(inputTuple);
+		input.inputs = buffer.read<int>();
+		input.theta = buffer.read<float>();
+		input.phi = buffer.read<float>();
 		playerInputs.push_back(input);
 	};
 

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -29,8 +29,7 @@ int main(int argc, char **argv) {
 		PlayerInputs input;
 		input.id = c->getId();
 		input.inputs = buffer.read<int>();
-		input.theta = buffer.read<float>();
-		input.phi = buffer.read<float>();
+		input.direction = buffer.read<vec3>();
 		playerInputs.push_back(input);
 	};
 

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
 	});
 
 	//This is the total amount of time allowed for the server to update the game state
-	auto maxAllowabeServerTime = std::chrono::milliseconds(1000 / TICKS_PER_SECOND);
+	auto maxAllowabeServerTime = std::chrono::milliseconds(1000 / TICKS_PER_SECOND + 10);
 
 	while (true) 
 	{
@@ -114,7 +114,7 @@ int main(int argc, char **argv) {
 		auto totalDuration = std::chrono::duration_cast<std::chrono::milliseconds>(updateDone - startTime);
 
 		//check if the server is running on schedule
-		if (updateDuration < maxAllowabeServerTime) 
+		if (updateDuration <= maxAllowabeServerTime) 
 		{
 			//wait for the update time to broadcast the game state update
 			std::this_thread::sleep_for(maxAllowabeServerTime - totalDuration);
@@ -122,7 +122,7 @@ int main(int argc, char **argv) {
 		else 
 		{
 			//server has taken too long to process the update!
-			std::cerr << "SERVER TOOK TOO LONG TO UPDATE!" << endl;
+			//std::cerr << "SERVER TOOK TOO LONG TO UPDATE!" << endl;
 		}
 	
 		gameEngine.synchronizeGameState();

--- a/Shared/Shared/CommonStructs.h
+++ b/Shared/Shared/CommonStructs.h
@@ -13,9 +13,8 @@ enum PlayerCommands {
 };
 
 struct PlayerInputs {
+	vec3 direction;
 	int inputs;
-	float theta;
-	float phi;
 	int id;
 };
 

--- a/Shared/Shared/GameObject.cpp
+++ b/Shared/Shared/GameObject.cpp
@@ -91,7 +91,16 @@ void GameObject::updateOnServerTick() {
 	return;
 }
 
+void GameObject::setOrientation(const quat &newOrientation) {
+	orientation = newOrientation;
+}
+
+const quat &GameObject::getOrientation() const {
+	return orientation;
+}
+
 void GameObject::serialize(NetBuffer &buffer) const {
+	buffer.write<quat>(orientation);
 	buffer.write<vec3>(position);
 	buffer.write<vec3>(velocity);
 	buffer.write<vec3>(scale);
@@ -100,6 +109,7 @@ void GameObject::serialize(NetBuffer &buffer) const {
 }
 
 void GameObject::deserialize(NetBuffer &buffer) {
+	orientation = buffer.read<quat>();
 	position = buffer.read<vec3>();
 	velocity = buffer.read<vec3>();
 	scale = buffer.read<vec3>();

--- a/Shared/Shared/GameObject.h
+++ b/Shared/Shared/GameObject.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "Common.h"
 #include "Networking/Serializable.h"
+#include <glm/gtx/quaternion.hpp>
+
+using glm::quat;
 
 enum GAMEOBJECT_TYPES {
 	GAMEOBJECT_TYPE,
@@ -44,7 +47,11 @@ public:
 	void setModel(const std::string &newModel);
 	string getModel() const;
 
+	void setOrientation(const quat &newOrientation);
+	const quat &getOrientation() const;
+
 protected:
+	quat orientation = quat();
 	vec3 position;
 	vec3 velocity;
 	vec3 scale = vec3(1.0f);

--- a/Shared/Shared/Player.cpp
+++ b/Shared/Shared/Player.cpp
@@ -38,10 +38,10 @@ vec3 Player::getMoveDestination(vec3 movement) {
 	vec3 up = vec3(0, 1, 0);
 
 	if (movement.z > 0) {
-		directionalizedMovement = directionalizedMovement + direction;
+		directionalizedMovement = directionalizedMovement - direction;
 	}
 	if (movement.z < 0) {
-		directionalizedMovement = directionalizedMovement - direction;
+		directionalizedMovement = directionalizedMovement + direction;
 	}
 	if (movement.x < 0) {
 		directionalizedMovement = directionalizedMovement + glm::cross(up, direction);

--- a/Shared/Shared/Player.cpp
+++ b/Shared/Shared/Player.cpp
@@ -1,6 +1,7 @@
 #include "Player.h"
 #include <iostream>
 #include <glm/gtx/string_cast.hpp>
+#include <glm/gtx/euler_angles.hpp>
 
 Player::Player(vec3 position, vec3 velocity, vec3 direction, int id, int radius) : GameObject(position, velocity, id, radius) {
 	this->direction = direction;
@@ -20,6 +21,7 @@ void Player::setDirection(const vec3 &newDirection) {
 		return;
 	}
 	direction = glm::normalize(newDirection);
+	setOrientation(glm::quatLookAt(direction, vec3(0, 1, 0)));
 }
 
 vec3 Player::getDirection() {


### PR DESCRIPTION
This PR adds an `orientation` (for orientation of objects) field to `GameObject` which is synchronized between the server and client. It then adds code to sent the player's camera direction to the server and sets the player's orientation to match the camera direction.

![20190509_152257](https://user-images.githubusercontent.com/19870477/57490637-b7f88f80-726e-11e9-911e-4f8d45faa38d.gif)

Closes #37 .