### PR TITLE
Easier `addGameObject`

### DIFF
--- a/Server/GameEngine.cpp
+++ b/Server/GameEngine.cpp
@@ -174,7 +174,7 @@ void GameEngine::doCollisionInteractions() {
 void GameEngine::removeDeadObjects() {
 	for (GameObject * gameObject : gameState.gameObjects) {
 		if (gameObject && gameObject->deleteOnServerTick()) {
-			delete gameObject;
+			removeGameObjectById(gameObject->getId());
 		}
 	}
 }

--- a/Server/GameEngine.h
+++ b/Server/GameEngine.h
@@ -21,6 +21,15 @@ public:
 	void updateGameState(vector<PlayerInputs> & playerInputs);
 	void synchronizeGameState();
 	GameState & getGameState();
+	
+	template<class T>
+	T* addGameObject() {
+		auto id = gameState.getFreeId();
+		auto obj = new T(id);
+		addGameObject(obj);
+		return obj;
+	}
+
 	void addGameObject(Player *player);
 	void addGameObject(Ball *ball);
 	void addGameObject(Wall *wall);

--- a/Server/Networking/Server.cpp
+++ b/Server/Networking/Server.cpp
@@ -4,14 +4,14 @@
 
 tcp::endpoint *Network::endpoint = nullptr;
 tcp::acceptor *Network::acceptor = nullptr;
-Connection* Network::connections[MAX_PLAYERS]; // Array of active connections.
+Connection* Network::connections[MAX_CONNECTIONS]; // Array of active connections.
 
 tcp::socket *newSocket = nullptr; // Reserve a socket for the next new connection.
 
 std::vector<Network::ConnectionHandler> connectionHandlers;
 
 int Network::findFreeId() {
-	for (int i = 0; i < MAX_PLAYERS; i++) {
+	for (int i = 0; i < MAX_CONNECTIONS; i++) {
 		if (!connections[i]) {
 			return i;
 		}
@@ -20,7 +20,7 @@ int Network::findFreeId() {
 }
 
 void Network::handleClientDisconnect(Connection *connection) {
-	for (int i = 0; i < MAX_PLAYERS; i++) {
+	for (int i = 0; i < MAX_CONNECTIONS; i++) {
 		if (connections[i] == connection) {
 			// TODO: change this so the connection is deleted in the next tick
 			// since other handlers still need the connection to exist.

--- a/Server/Networking/Server.h
+++ b/Server/Networking/Server.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <Shared/Networking/Connection.h>
 
-constexpr auto MAX_PLAYERS = 256;
+constexpr auto MAX_CONNECTIONS = 256;
 
 using boost::asio::ip::tcp;
 using boost::system::error_code;
@@ -14,7 +14,7 @@ namespace Network {
 
 	extern tcp::endpoint *endpoint;
 	extern tcp::acceptor *acceptor;
-	extern Connection *connections[MAX_PLAYERS];
+	extern Connection *connections[MAX_CONNECTIONS];
 
 	void init(int port);
 	void handleIncomingConnection(const error_code &error);

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -19,8 +19,7 @@ int main(int argc, char **argv) {
 
 	vector<PlayerInputs> playerInputs;
 
-	auto ground = new Wall(origin, origin, 100, 1);
-	gameEngine.addGameObject(ground);
+	auto ground = gameEngine.addGameObject<Wall>();
 	ground->setModel("Models/ground.obj");
 	ground->setMaterial("Materials/grass.json");
 

--- a/Shared/Shared/Ball.h
+++ b/Shared/Shared/Ball.h
@@ -3,6 +3,8 @@
 
 class Ball : public GameObject {
 public:
+	using GameObject::GameObject;
+
 	Ball(vec3 position, vec3 velocity, int id, int radius);
 	GAMEOBJECT_TYPES getGameObjectType() const;
 	void onCollision(GameObject * gameObject);

--- a/Shared/Shared/GameState.h
+++ b/Shared/Shared/GameState.h
@@ -3,6 +3,9 @@
 #include "Ball.h"
 #include "Wall.h"
 
+// Maximum number of players in the game.
+constexpr auto MAX_PLAYERS = 4;
+
 struct GameState : public Serializable {
 	vector<Player *> players;
 	vector<Ball *> balls;
@@ -13,6 +16,16 @@ struct GameState : public Serializable {
 	bool in_progress;
 
 	GameState() : gameObjects(1024, nullptr) { }
+
+	int getFreeId() const {
+		// Offset by MAX_PLAYERS to reserve IDs for players.
+		for (int id = MAX_PLAYERS; id < gameObjects.size(); id++) {
+			if (gameObjects[id] == nullptr) {
+				return id;
+			}
+		}
+		return -1;
+	}
 
 	void serialize(NetBuffer &buffer) const {
 		auto size = 0;

--- a/Shared/Shared/Paddle.h
+++ b/Shared/Shared/Paddle.h
@@ -3,6 +3,8 @@
 
 class Paddle : public GameObject {
 public:
+	using GameObject::GameObject;
+
 	Paddle(vec3 position, vec3 velocity, int id, int radius, int lifespan);
 	GAMEOBJECT_TYPES getGameObjectType() const;
 	bool deleteOnServerTick();

--- a/Shared/Shared/Wall.h
+++ b/Shared/Shared/Wall.h
@@ -3,6 +3,8 @@
 
 class Wall : public GameObject {
 public:
+	using GameObject::GameObject;
+
 	Wall(vec3 position, vec3 velocity, int id, int radius);
 	GAMEOBJECT_TYPES getGameObjectType() const;
 };


### PR DESCRIPTION
This PR adds a new function `GameEngine::addGameObject<T>` (where `T` is `Wall`, `Ball`, etc...) which will create any type of game object and set its ID for you. So, we don't have to figure out what ID to use for game objects.

For example, to create a wall, one can just write:
```c++
auto ground = gameEngine.addGameObject<Wall>();
ground->setModel("Models/ground.obj");
ground->setMaterial("Materials/grass.json");
```

This closes #40 .