### PR TITLE
Add sound for game objects

### DIFF
--- a/Client/ClientGameObject.cpp
+++ b/Client/ClientGameObject.cpp
@@ -1,6 +1,7 @@
 #include "ClientGameObject.h"
 #include <glm/gtx/transform.hpp>
 #include <glm/gtx/euler_angles.hpp>
+#include "Sound/SoundEngine.h"
 
 ClientGameObject::ClientGameObject(std::unique_ptr<GameObject> gameObject)
 : gameObject(std::move(gameObject)) { }
@@ -74,9 +75,43 @@ GameObject *ClientGameObject::getGameObject() const {
 	return gameObject.get();
 }
 
+void ClientGameObject::playSound(const string &sound, float volume, bool loop) {
+	auto it = sounds.find(sound);
+	if (it != sounds.end()) {
+		delete sounds[sound];
+	}
+	auto soundObj = gSound->loadSpatialSound(sound, volume);
+	soundObj->play(loop);
+	sounds[sound] = soundObj;
+}
+
+void ClientGameObject::stopSound(const string &sound) {
+	auto it = sounds.find(sound);
+	if (it != sounds.end()) {
+		delete sounds[sound];
+		sounds.erase(it);
+	}
+}
+
+void ClientGameObject::updateSound() {
+	for (auto &pathAndSound : sounds) {
+		auto sound = pathAndSound.second;
+		sound->setPosition(gameObject->getPosition());
+		sound->setVelocity(gameObject->getVelocity());
+	}
+}
+
+void ClientGameObject::update(float time) {
+	updateAnimation(time);
+	updateSound();
+}
+
 ClientGameObject::~ClientGameObject() {
 	if (model) {
 		delete model;
 		model = nullptr;
+	}
+	for (auto &pathAndSound : sounds) {
+		delete pathAndSound.second;
 	}
 }

--- a/Client/ClientGameObject.h
+++ b/Client/ClientGameObject.h
@@ -8,12 +8,16 @@
 #include "Renderer/DrawPass.h"
 #include "Sound/Sound.h"
 #include <memory>
+#include <unordered_map>
 
 class ClientGameObject {
 protected:
 	Model *model = nullptr;
 	Material *material = nullptr;
 	std::unique_ptr<GameObject> gameObject;
+	std::unordered_map<string, Sound*> sounds;
+	void updateAnimation(float time);
+	void updateSound();
 
 public:
 	ClientGameObject(std::unique_ptr<GameObject> gameObject);
@@ -22,7 +26,9 @@ public:
 	void setModel(const std::string &newModel);
 	void setMaterial(const std::string &newMaterial);
 	void setAnimation(int id = -1, bool restart = true);
-	void updateAnimation(float time);
+	void playSound(const string &sound, float volume = 1.0f, bool loop = false);
+	void stopSound(const string &sound);
+	void update(float time);
 	GameObject *getGameObject() const;
 	Model *getModel() const;
 	Material *getMaterial() const;

--- a/Client/Game.h
+++ b/Client/Game.h
@@ -36,10 +36,7 @@ class Game {
 
 	std::vector<ClientGameObject*> gameObjects;
 
-	SoundEngine *soundEngine = nullptr;
 	Sound *soundtrack = nullptr;
-	Sound *spatialTest1 = nullptr;
-	Sound *spatialTest2 = nullptr;
 
 	int playerId;
 
@@ -63,6 +60,7 @@ public:
 	void onGameObjectModelSet(Connection *c, NetBuffer &buffer);
 	void onGameObjectAnimSet(Connection *c, NetBuffer &buffer);
 	void onGameObjectMaterialSet(Connection *c, NetBuffer &buffer);
+	void onPlaySound(Connection *c, NetBuffer &buffer);
 
 	int getScreenWidth() const;
 	int getScreenHeight() const;

--- a/Client/Game/ParticleEmitters.cpp
+++ b/Client/Game/ParticleEmitters.cpp
@@ -40,14 +40,14 @@ void ParticleEmitters::onDelete(Connection *c, NetBuffer &buffer) {
 }
 
 void ParticleEmitters::update(float dt, const Camera *camera) {
-	for (auto system : systems) {
+	for (auto &system : systems) {
 		system.second->update(dt, camera);
 	}
 }
 
 void ParticleEmitters::draw(const Camera *camera) {
 	static auto psShader = new Shader("Shaders/particle");
-	for (auto system : systems) {
+	for (auto &system : systems) {
 		system.second->draw(*psShader, camera);
 	}
 }

--- a/Client/GameObject.cpp
+++ b/Client/GameObject.cpp
@@ -9,3 +9,8 @@ void GameObject::setAnimation(int newAnimation, bool reset) { DO_NOT_CALL; }
 std::string GameObject::getModel() const { DO_NOT_CALL; return ""; }
 std::string GameObject::getMaterial() const { DO_NOT_CALL; return ""; }
 int GameObject::getAnimation() const { DO_NOT_CALL; return -1; }
+
+void GameObject::playSound(const string &sound, float volume, bool loop) {
+	DO_NOT_CALL;
+}
+void GameObject::stopSound(const string &sound) { DO_NOT_CALL; }

--- a/Client/Sound/Sound.cpp
+++ b/Client/Sound/Sound.cpp
@@ -32,15 +32,15 @@ void Sound::setVolume(float volume) {
 	sound->setVolume(volume);
 }
 
-void Sound::setPosition(vec3 pos) {
+void Sound::setPosition(const vec3 &pos) {
 	if (!sound || !isSpatial) { return; }
-	irrklang::vec3df soundPos = irrklang::vec3df(pos.x, pos.y, pos.z);
+	irrklang::vec3df soundPos(pos.x, pos.y, pos.z);
 	sound->setPosition(soundPos);
 }
 
-void Sound::setVelocity(vec3 vel) {
+void Sound::setVelocity(const vec3 &vel) {
 	if (!sound || !isSpatial) { return; }
-	irrklang::vec3df soundVel = irrklang::vec3df(vel.x, vel.y, vel.z);
+	irrklang::vec3df soundVel(vel.x, vel.y, vel.z);
 	sound->setVelocity(soundVel);
 }
 
@@ -52,4 +52,9 @@ void Sound::setMinDist(float dist) {
 void Sound::setMaxDist(float dist) {
 	if (!sound || !isSpatial) { return; }
 	sound->setMaxDistance(dist);
+}
+
+void Sound::stop() {
+	if (!sound) { return; }
+	sound->stop();
 }

--- a/Client/Sound/Sound.h
+++ b/Client/Sound/Sound.h
@@ -12,10 +12,11 @@ public:
 	void play(const bool isLooping);
 	void pause();
 	void setVolume(float volume);
-	void setPosition(vec3 pos);
-	void setVelocity(vec3 vel);
+	void setPosition(const vec3 &pos);
+	void setVelocity(const vec3 &vel);
 	void setMinDist(float dist);
 	void setMaxDist(float dist);
+	void stop();
 
 private:
 	std::string filepath;

--- a/Client/Sound/SoundEngine.cpp
+++ b/Client/Sound/SoundEngine.cpp
@@ -4,6 +4,7 @@ const std::string ERRKLANG_ERROR_MSG = "Error: irrKlang audio failed to initiali
 
 SoundEngine::SoundEngine() {
 	engine = irrklang::createIrrKlangDevice();
+	engine->setDefault3DSoundMinDistance(3.0f);
 	if (!engine) {
 		std::cout << ERRKLANG_ERROR_MSG << std::endl;
 		didInitialize = false;
@@ -18,9 +19,6 @@ SoundEngine::~SoundEngine() {
 }
 
 bool SoundEngine::isInitialized() {
-	if (!didInitialize)
-		// std::cout << ERRKLANG_ERROR_MSG << std::endl;
-
 	return didInitialize;
 }
 
@@ -57,3 +55,5 @@ void SoundEngine::update(vec3 pos, vec3 vel, vec3 lookDir) {
 	engine->setListenerPosition(position, lookAt, velocity);
 	engine->update();
 }
+
+SoundEngine *gSound = new SoundEngine();

--- a/Client/Sound/SoundEngine.h
+++ b/Client/Sound/SoundEngine.h
@@ -22,3 +22,4 @@ private:
 	bool didInitialize = false;
 };
 
+extern SoundEngine *gSound;

--- a/Client/main.cpp
+++ b/Client/main.cpp
@@ -26,7 +26,10 @@ static void onResize(GLFWwindow *window, int width, int height) {
 	SCREEN_HEIGHT = height;
 	SCREEN_RESHAPED = true;
 
-	Draw::updateScreenDimensions(width, height);
+	Draw::updateScreenDimensions(
+		static_cast<float>(width),
+		static_cast<float>(height)
+	);
 	glViewport(0, 0, width, height);
 }
 

--- a/Server/GameObject.cpp
+++ b/Server/GameObject.cpp
@@ -37,3 +37,16 @@ void GameObject::setMaterial(const std::string &newMaterial) {
 string GameObject::getMaterial() const {
 	return material;
 }
+
+void GameObject::playSound(const string &sound, float volume, bool loop) {
+	NetBuffer buffer(NetMessage::SOUND);
+	buffer.write(id);
+	buffer.write(sound);
+	buffer.write(volume);
+	buffer.write(loop);
+	Network::broadcast(buffer);
+}
+
+void GameObject::stopSound(const string &sound) {
+	playSound(sound, -1.0f, false);
+}

--- a/Server/main.cpp
+++ b/Server/main.cpp
@@ -36,7 +36,6 @@ int main(int argc, char **argv) {
 	ball->setModel("Models/sphere.obj");
 	ball->setMaterial("Materials/brick.json");
 
-
 	// Handle player keyboard/mouse inputs
 	auto handlePlayerInput = [&playerInputs](Connection *c, NetBuffer &buffer) {
 		PlayerInputs input;
@@ -101,6 +100,8 @@ int main(int argc, char **argv) {
 		ps->setCreationSpeed(500);
 		ps->setInitialVel(vec3(0, 10, 0));
 		ps->setTexture("Textures/gary.png");
+
+		ball->playSound("Sounds/minecraft_chicken_ambient.ogg", 1.0f, true);
 
 		// Receive player keyboard and mouse(TODO) input
 		c->on(NetMessage::PLAYER_INPUT, handlePlayerInput);

--- a/Shared/Shared/GameObject.h
+++ b/Shared/Shared/GameObject.h
@@ -63,6 +63,9 @@ public:
 	void setOrientation(const quat &newOrientation);
 	const quat &getOrientation() const;
 
+	void playSound(const string &sound, float volume = 1.0f, bool loop = false);
+	void stopSound(const string &sound);
+
 protected:
 	quat orientation = quat();
 	vec3 position;

--- a/Shared/Shared/Networking/NetMessage.h
+++ b/Shared/Shared/Networking/NetMessage.h
@@ -13,4 +13,5 @@ enum NetMessage {
 	GAME_OBJ_MAT,
 	PARTICLES,
 	PARTICLES_DELETE,
+	SOUND,
 };


### PR DESCRIPTION
This PR adds a `GameObject` method on the server to play a sound from an object, `GameObject::playSound(string sound, float volume = 1.0, bool loop = false)`.

For example:
```c++
ball->playSound("Sounds/minecraft_chicken_ambient.ogg");
```

All the clients will hear the sound if they are close enough and the sound will follow the game object if it moves.