### PR TITLE
Particle Emitter Parenting

### DIFF
--- a/Client/Game.cpp
+++ b/Client/Game.cpp
@@ -104,6 +104,7 @@ int Game::getScreenHeight() const {
 
 Game::Game() : gameObjects({ nullptr }) {
 	Draw::init();
+	ParticleEmitters::init(&gameState);
 
 	// TODO (bhang): Integrate this with connecting.
 	// Gui::create<GuiConnectMenu>();

--- a/Client/Game/ParticleEmitter.cpp
+++ b/Client/Game/ParticleEmitter.cpp
@@ -3,8 +3,12 @@
 
 ParticleEmitter::ParticleEmitter() { }
 
-void ParticleEmitter::update() const { }
+void ParticleEmitter::update() { }
 
 void ParticleEmitter::updateAll() { }
+
+void ParticleEmitter::setParent(GameObject*) { }
+
+GameObject *ParticleEmitter::getParent() const { return nullptr; }
 
 ParticleEmitter::~ParticleEmitter() { }

--- a/Client/Game/ParticleEmitters.cpp
+++ b/Client/Game/ParticleEmitters.cpp
@@ -2,7 +2,12 @@
 #include "../Assets.h"
 
 unordered_map<size_t, ParticleSystem*> ParticleEmitters::systems;
+GameState *ParticleEmitters::gameState = nullptr;
 static Shader *psShader = nullptr;
+
+void ParticleEmitters::init(GameState *newGameState) {
+	gameState = newGameState;
+}
 
 void ParticleEmitters::onUpdate(Connection *c, NetBuffer &buffer) {
 	const auto id = buffer.read<size_t>();
@@ -29,6 +34,7 @@ void ParticleEmitters::onUpdate(Connection *c, NetBuffer &buffer) {
 	system->collFriction = emitter._CollFriction;
 	system->particleColor = emitter._ParticleColor;
 	system->texture = Assets::getTexture2d(emitter._Texture);
+	system->parentId = emitter._ParentId;
 }
 
 void ParticleEmitters::onDelete(Connection *c, NetBuffer &buffer) {
@@ -40,8 +46,14 @@ void ParticleEmitters::onDelete(Connection *c, NetBuffer &buffer) {
 }
 
 void ParticleEmitters::update(float dt, const Camera *camera) {
-	for (auto &system : systems) {
-		system.second->update(dt, camera);
+	for (auto &idAndSystem : systems) {
+		auto system = idAndSystem.second;
+
+		if (gameState && system->parentId >= 0) {
+			auto parent = gameState->gameObjects[system->parentId];
+			system->initialPos = parent->getPosition();
+		}
+		system->update(dt, camera);
 	}
 }
 

--- a/Client/Game/ParticleEmitters.h
+++ b/Client/Game/ParticleEmitters.h
@@ -2,6 +2,10 @@
 
 #include <unordered_map>
 #include <Shared/Game/ParticleEmitter.h>
+
+struct GameState;
+#include <Shared/GameState.h>
+
 #include "../Networking/Client.h"
 #include "../Renderer/ParticleSystem.h"
 #include "../Renderer/Camera.h"
@@ -10,7 +14,9 @@ using std::unordered_map;
 
 namespace ParticleEmitters {
 	extern unordered_map<size_t, ParticleSystem*> systems;
+	extern GameState *gameState;
 
+	void init(GameState *newGameState);
 	void onUpdate(Connection *c, NetBuffer &buffer);
 	void onDelete(Connection *c, NetBuffer &buffer);
 	void update(float dt, const Camera *camera);

--- a/Client/Renderer/ParticleSystem.cpp
+++ b/Client/Renderer/ParticleSystem.cpp
@@ -33,7 +33,9 @@ ParticleSystem::ParticleSystem(const unsigned int maxParticles, const float part
 	, collFriction(0.2f)
 	, particleColor(vector<vec4>{ vec4(1.0f), vec4(1.0f, 1.0f, 1.0f, 0.0f) })
 	, VAO(0)
-	, texture(Assets::getTexture2d("Textures/white.png")) {
+	, texture(Assets::getTexture2d("Textures/white.png"))
+	, parentId(-1)
+{
 
 	for (unsigned int i = 0; i < maxParticles; i++)
 	{

--- a/Client/Renderer/ParticleSystem.h
+++ b/Client/Renderer/ParticleSystem.h
@@ -30,6 +30,7 @@ public:
 	float collFriction;           // For ground plane collision
 	vector<vec4> particleColor;   // Color of each particle during its lifetime
 	Texture2d *texture;           // Texture for each particle
+	int parentId;                 // ID of object to follow
 
 private:
 	void setupBuffers();

--- a/Server/Game/ParticleEmitter.cpp
+++ b/Server/Game/ParticleEmitter.cpp
@@ -27,13 +27,15 @@ ParticleEmitter::ParticleEmitter()
 	, _CollFriction(0.2f)
 	, _ParticleColor({ vec4(1.0f), vec4(1.0f, 1.0f, 1.0f, 0.0f) })
 	, _Texture("Textures/white.png")
+	, _ParentId(-1)
+	, parent(nullptr)
 {
 	id = nextId;
 	nextId++;
 	emitters.push_back(this);
 }
 
-void ParticleEmitter::update() const {
+void ParticleEmitter::update() {
 	if (dieTime > 0 && dieTime <= curTime()) {
 		NetBuffer buffer(NetMessage::PARTICLES_DELETE);
 		buffer.write(id);
@@ -44,6 +46,7 @@ void ParticleEmitter::update() const {
 	}
 	if (updateNextTick) {
 		Network::broadcast(NetMessage::PARTICLES, *this);
+		updateNextTick = false;
 	}
 }
 
@@ -55,6 +58,15 @@ void ParticleEmitter::updateAll() {
 
 void ParticleEmitter::setLifeTime(float seconds) {
 	dieTime = curTime() + seconds;
+}
+
+void ParticleEmitter::setParent(GameObject *newParent) {
+	parent = newParent;
+	setParentId(parent ? parent->getId() : -1);
+}
+
+GameObject *ParticleEmitter::getParent() const {
+	return parent;
 }
 
 ParticleEmitter::~ParticleEmitter() {

--- a/Shared/Shared/Game/ParticleEmitter.cpp
+++ b/Shared/Shared/Game/ParticleEmitter.cpp
@@ -19,6 +19,7 @@ void ParticleEmitter::serialize(NetBuffer &buffer) const {
 	buffer.write(_CollElasticity);
 	buffer.write(_CollFriction);
 	buffer.write(_Texture);
+	buffer.write(_ParentId);
 	buffer.write(_ParticleColor.size());
 	for (auto &color : _ParticleColor) {
 		buffer.write(color);
@@ -40,6 +41,7 @@ void ParticleEmitter::deserialize(NetBuffer &buffer) {
 	_CollElasticity = buffer.read<float>();
 	_CollFriction = buffer.read<float>();
 	_Texture = buffer.read<string>();
+	_ParentId = buffer.read<int>();
 
 	const auto numColors = buffer.read<size_t>();
 	_ParticleColor.resize(numColors);

--- a/Shared/Shared/Game/ParticleEmitter.h
+++ b/Shared/Shared/Game/ParticleEmitter.h
@@ -2,6 +2,7 @@
 
 #include "../Common.h"
 #include "../Networking/Serializable.h"
+#include "../GameObject.h"
 
 // Defines a member variable with a setter that synchronizes the state on client.
 #define PARTICLE_PARAM(type, var) \
@@ -18,6 +19,7 @@ class ParticleEmitter : public Serializable {
 	size_t id;            // A unique number used to identify this emitter.
 	static size_t nextId; // Unique number for the next emitter.
 	float dieTime;        // When the emitter should be auto-deleted. -1 = never
+	GameObject *parent;   // Object that this emitter should follow.
 
 	public:
 	PARTICLE_PARAM(unsigned int, CreationSpeed);
@@ -35,6 +37,7 @@ class ParticleEmitter : public Serializable {
 	PARTICLE_PARAM(float, CollFriction);
 	PARTICLE_PARAM(vector<vec4>, ParticleColor);
 	PARTICLE_PARAM(string, Texture);
+	PARTICLE_PARAM(int, ParentId);
 
 	ParticleEmitter();
 
@@ -42,10 +45,16 @@ class ParticleEmitter : public Serializable {
 	void deserialize(NetBuffer &buffer) override;
 
 	// Sends state to client so it can be synchronized.
-	void update() const;  
+	void update();  
 
 	// Sets how long this emitter stays active for.
 	void setLifeTime(float seconds); 
+
+	// Sets the game object that this emitter should be attached to.
+	void setParent(GameObject *newParent);
+
+	// Returns the object this emitter is attached to.
+	GameObject *getParent() const;
 
 	~ParticleEmitter();
 

--- a/Shared/Shared/GameState.h
+++ b/Shared/Shared/GameState.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "GameObject.h"
 #include "Player.h"
 #include "Ball.h"


### PR DESCRIPTION
This PR adds the ability to make a `ParticleEmitter` follow a `GameObject` by setting its parent to the object.

Closes #54 .