### PR TITLE
Add creation interval for particles

### DIFF
--- a/Client/Game/ParticleEmitters.cpp
+++ b/Client/Game/ParticleEmitters.cpp
@@ -29,6 +29,7 @@ void ParticleEmitters::onUpdate(Connection *c, NetBuffer &buffer) {
 	system->collFriction = emitter._CollFriction;
 	system->particleColor = emitter._ParticleColor;
 	system->texture = Assets::getTexture2d(emitter._Texture);
+	system->creationTime = emitter._CreationTime;
 }
 
 void ParticleEmitters::onDelete(Connection *c, NetBuffer &buffer) {

--- a/Client/Renderer/ParticleSystem.cpp
+++ b/Client/Renderer/ParticleSystem.cpp
@@ -33,6 +33,7 @@ ParticleSystem::ParticleSystem(const unsigned int maxParticles, const float part
 	, collFriction(0.2f)
 	, particleColor(vector<vec4>{ vec4(1.0f), vec4(1.0f, 1.0f, 1.0f, 0.0f) })
 	, VAO(0)
+	, creationTime(1.0f)
 	, texture(Assets::getTexture2d("Textures/white.png")) {
 
 	for (unsigned int i = 0; i < maxParticles; i++)
@@ -110,9 +111,9 @@ void ParticleSystem::setupBuffers() {
 
 void ParticleSystem::update(float dt, const Camera *camera) {
 	creationTimer += dt;
-	if (creationTimer > 1.0f)
+	if (creationTimer >= creationTime)
 	{
-		creationTimer -= 1.0f;
+		creationTimer = 0.0f;
 		for (unsigned int i = 0; i < creationSpeed; i++)
 		{
 			if (numParticles >= maxParticles) break;

--- a/Client/Renderer/ParticleSystem.h
+++ b/Client/Renderer/ParticleSystem.h
@@ -16,6 +16,7 @@ public:
 	void draw(Shader &shader, const Camera *camera);
 
 	unsigned int creationSpeed;   // Particles per second
+	float creationTime;           // Time between particle creation
 	vec3 initialPos;              // Initial position
 	vec3 initialPosVariance;      // +/- from initial position
 	vec3 initialVel;              // Initial velocity

--- a/Server/Game/ParticleEmitter.cpp
+++ b/Server/Game/ParticleEmitter.cpp
@@ -27,6 +27,7 @@ ParticleEmitter::ParticleEmitter()
 	, _CollFriction(0.2f)
 	, _ParticleColor({ vec4(1.0f), vec4(1.0f, 1.0f, 1.0f, 0.0f) })
 	, _Texture("Textures/white.png")
+	, _CreationTime(1.0f)
 {
 	id = nextId;
 	nextId++;

--- a/Shared/Shared/Game/ParticleEmitter.cpp
+++ b/Shared/Shared/Game/ParticleEmitter.cpp
@@ -19,6 +19,7 @@ void ParticleEmitter::serialize(NetBuffer &buffer) const {
 	buffer.write(_CollElasticity);
 	buffer.write(_CollFriction);
 	buffer.write(_Texture);
+	buffer.write(_CreationTime);
 	buffer.write(_ParticleColor.size());
 	for (auto &color : _ParticleColor) {
 		buffer.write(color);
@@ -40,6 +41,7 @@ void ParticleEmitter::deserialize(NetBuffer &buffer) {
 	_CollElasticity = buffer.read<float>();
 	_CollFriction = buffer.read<float>();
 	_Texture = buffer.read<string>();
+	_CreationTime = buffer.read<float>();
 
 	const auto numColors = buffer.read<size_t>();
 	_ParticleColor.resize(numColors);

--- a/Shared/Shared/Game/ParticleEmitter.h
+++ b/Shared/Shared/Game/ParticleEmitter.h
@@ -35,6 +35,7 @@ class ParticleEmitter : public Serializable {
 	PARTICLE_PARAM(float, CollFriction);
 	PARTICLE_PARAM(vector<vec4>, ParticleColor);
 	PARTICLE_PARAM(string, Texture);
+	PARTICLE_PARAM(float, CreationTime);
 
 	ParticleEmitter();
 


### PR DESCRIPTION
This PR adds a method `ParticleEmitter::setCreationTime(float time)` which sets how often new particles get made.